### PR TITLE
fix: ejabberd/conversejs http-bind to use tls

### DIFF
--- a/mywebsite/chat.html
+++ b/mywebsite/chat.html
@@ -10,7 +10,7 @@
 <body>
     <script>
         converse.initialize({
-            bosh_service_url: 'http://nargothrond.xyz:5280/bosh/',
+            bosh_service_url: 'https://nargothrond.xyz:5280/bosh/',
             view_mode: 'fullscreen'
         });
     </script>


### PR DESCRIPTION
Forgot the `tls = true` option in `/opt/ejabberd/conf/ejabberd.yml`:

```yaml
    port: 5280
    ip: "::"
    module: ejabberd_http
    tls: true
    request_handlers:
      /admin: ejabberd_web_admin
      /bosh: mod_bosh
      /.well-known/acme-challenge: ejabberd_acme
```